### PR TITLE
CancelButton fits the size after setting localized title

### DIFF
--- a/TOPasscodeViewController/TOPasscodeViewController.m
+++ b/TOPasscodeViewController/TOPasscodeViewController.m
@@ -461,6 +461,7 @@
     [UIView performWithoutAnimation:^{
         if (title != nil) {
             [self.cancelButton setTitle:title forState:UIControlStateNormal];
+            [self.cancelButton sizeToFit];
             [self.cancelButton layoutIfNeeded];
         }
         self.cancelButton.hidden = (title == nil);


### PR DESCRIPTION
Bug: when I set cancelButton localized title longer than "Delete" (i.e. "Deeeeleeeetee"), I see only "De...tee"

Fix: Call _sizeToFit_ after setting title

